### PR TITLE
Add stability dev flag to manual install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Enter the commands below to create a a new site on Pantheon and push a copy of t
 ```
 $ SITE="my-site"
 $ terminus site:create $SITE "My Site" "Drupal 7" --org="My Team"
-$ composer create-project pantheon-systems/example-drops-7-composer $SITE
+$ composer create-project pantheon-systems/example-drops-7-composer $SITE -s dev
 $ cd $SITE
 $ composer prepare-for-pantheon
 $ git init


### PR DESCRIPTION
The packagist project is currently not marked as stable, so composer will refuse to create the project, we had a customer run into this and I found this flag allows the project to finish.